### PR TITLE
Allow increasing dimension when within min size

### DIFF
--- a/croppie.js
+++ b/croppie.js
@@ -467,7 +467,8 @@
         var direction;
         var originalX;
         var originalY;
-        var minSize = 50;
+        var minWidth = 0;
+        var minHeight = 0;
         var maxWidth;
         var maxHeight;
         var sizeInfo;
@@ -499,6 +500,13 @@
             hr = document.createElement('div');
             addClass(hr, 'cr-resizer-horisontal');
             wrap.appendChild(hr);
+        }
+
+        if (this.options.resizeControls.minWidth > 0) {
+            minWidth = this.options.resizeControls.minWidth;
+        }
+        if (this.options.resizeControls.minHeight > 0) {
+            minHeight = this.options.resizeControls.minHeight;
         }
 
         function mouseDown(ev) {
@@ -571,7 +579,7 @@
             var newHeight = self.options.viewport.height + deltaY;
             var newWidth = self.options.viewport.width + deltaX;
 
-            if (direction === 'v' && newHeight >= minSize && newHeight <= maxHeight) {
+            if (direction === 'v' && (newHeight >= minHeight || deltaY > 0) && newHeight <= maxHeight) {
                 css(wrap, {
                     height: newHeight + 'px'
                 });
@@ -586,7 +594,7 @@
                     height: self.options.viewport.height + 'px'
                 });
             }
-            else if (direction === 'h' && newWidth >= minSize && newWidth <= maxWidth) {
+            else if (direction === 'h' && (newWidth >= minWidth || deltaX > 0) && newWidth <= maxWidth) {
                 css(wrap, {
                     width: newWidth + 'px'
                 });
@@ -1631,6 +1639,8 @@
         resizeControls: {
             width: true,
             height: true,
+            minWidth: null,
+            minHeight: null,
             maxWidth: null,
             maxHeight: null,
             sizeInfo: false,


### PR DESCRIPTION
The resizer had a minimum size of 50 pixels for both dimensions,
preventing resizing below this limit. This default limit is removed, and
made configurable. The only limit now is that one can't resize to a
negative size in either dimension.

But if Croppie is initialized with an image that is already smaller than the
configured minimum size in a given dimension it was then impossible to
resize it to a larger size in that dimension.

This also allows increasing the size of a dimension even if the new
dimension size will still be smaller than the minimum size for that
dimension. This at least let's the user get the image up to minimum
size, but it's really left to the consumer of Croppie to ensure an image
initially is larger then the minimum size configured.